### PR TITLE
refactor(validate): remove need for `default` trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ test graphql_ast_print_apollo_parser  ... bench:      20,861 ns/iter (+/- 518)
 
 ```
 test graphql_ast_fold                 ... bench:       8,466 ns/iter (+/- 768)
-test graphql_ast_validate             ... bench:       2,339 ns/iter (+/- 127)
+test graphql_ast_validate             ... bench:       1,504 ns/iter (+/- 46)
 test graphql_load_introspection       ... bench:      90,265 ns/iter (+/- 4,899)
 ```
 

--- a/src/ast/ast_conversion.rs
+++ b/src/ast/ast_conversion.rs
@@ -62,6 +62,15 @@ pub trait DefaultIn<'a> {
     fn default_in(arena: &'a bumpalo::Bump) -> Self;
 }
 
+impl<'a, T> DefaultIn<'a> for T
+where
+    T: Default,
+{
+    fn default_in(_ctx: &'a bumpalo::Bump) -> Self {
+        Self::default()
+    }
+}
+
 impl<'a> DefaultIn<'a> for Document<'a> {
     fn default_in(arena: &'a bumpalo::Bump) -> Self {
         Document {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -38,5 +38,6 @@ mod printer;
 
 pub use ast::*;
 pub use ast_kind::ASTKind;
+pub use ast_conversion::DefaultIn;
 pub use parser::ParseNode;
 pub use printer::PrintNode;

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -24,7 +24,7 @@
 //! As such, the [`DefaultRules`](rules::DefaultRules) rule is a [`ValidationRule`] itself that's
 //! composed using the [`ComposedVisitor`](crate::visit::ComposedVisitor) utility.
 //!
-//! All rules must implement the `Default` trait, which makes it easier to quickly run a validation
+//! All rules must implement the `DefaultIn` trait, which makes it easier to quickly run a validation
 //! rule and isolates them from external state, since no validation requires any external state.
 //!
 //! For example, this is one way to run a validation rule, in this case `DefaultRules`:

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -24,7 +24,7 @@
 //! As such, the [`DefaultRules`](rules::DefaultRules) rule is a [`ValidationRule`] itself that's
 //! composed using the [`ComposedVisitor`](crate::visit::ComposedVisitor) utility.
 //!
-//! All rules must implement the `DefaultIn` trait, which makes it easier to quickly run a validation
+//! All rules must implement the [`DefaultIn`](crate::ast::DefaultIn) trait, which makes it easier to quickly run a validation
 //! rule and isolates them from external state, since no validation requires any external state.
 //!
 //! For example, this is one way to run a validation rule, in this case `DefaultRules`:

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -24,7 +24,7 @@
 //! As such, the [`DefaultRules`](rules::DefaultRules) rule is a [`ValidationRule`] itself that's
 //! composed using the [`ComposedVisitor`](crate::visit::ComposedVisitor) utility.
 //!
-//! All rules must implement the [`DefaultIn`](crate::ast::DefaultIn) trait, which makes it easier to quickly run a validation
+//! All rules must implement the [`DefaultIn`](crate::ast::DefaultIn) or `Default` trait, which makes it easier to quickly run a validation
 //! rule and isolates them from external state, since no validation requires any external state.
 //!
 //! For example, this is one way to run a validation rule, in this case `DefaultRules`:

--- a/src/validate/rules/known_fragment_names.rs
+++ b/src/validate/rules/known_fragment_names.rs
@@ -1,3 +1,5 @@
+use bumpalo::collections::Vec;
+
 use super::super::{ValidationContext, ValidationRule};
 use crate::{ast::*, visit::*};
 
@@ -5,10 +7,18 @@ use crate::{ast::*, visit::*};
 ///
 /// See [`ValidationRule`]
 /// [Reference](https://spec.graphql.org/October2021/#sec-Fragment-spread-target-defined)
-#[derive(Default)]
 pub struct KnownFragmentNames<'a> {
-    fragment_names: Vec<&'a str>,
-    fragment_spreads: Vec<&'a str>,
+    fragment_names: Vec<'a, &'a str>,
+    fragment_spreads: Vec<'a, &'a str>,
+}
+
+impl<'a> DefaultIn<'a> for KnownFragmentNames<'a> {
+    fn default_in(arena: &'a bumpalo::Bump) -> Self {
+        Self {
+            fragment_names: Vec::new_in(arena),
+            fragment_spreads: Vec::new_in(arena),
+        }
+    }
 }
 
 impl<'a> ValidationRule<'a> for KnownFragmentNames<'a> {}

--- a/src/validate/rules/lone_anonymous_operation.rs
+++ b/src/validate/rules/lone_anonymous_operation.rs
@@ -6,18 +6,10 @@ use crate::{ast::*, visit::*};
 ///
 /// See [`ValidationRule`]
 /// [Reference](https://spec.graphql.org/October2021/#sec-Lone-Anonymous-Operation)
+#[derive(Default)]
 pub struct LoneAnonymousOperation {
     operations: usize,
     has_anonymous: bool,
-}
-
-impl<'a> DefaultIn<'a> for LoneAnonymousOperation {
-    fn default_in(_arena: &'a bumpalo::Bump) -> Self {
-        Self {
-            operations: 0,
-            has_anonymous: false
-        }
-    }
 }
 
 impl<'a> ValidationRule<'a> for LoneAnonymousOperation {}

--- a/src/validate/rules/lone_anonymous_operation.rs
+++ b/src/validate/rules/lone_anonymous_operation.rs
@@ -6,10 +6,18 @@ use crate::{ast::*, visit::*};
 ///
 /// See [`ValidationRule`]
 /// [Reference](https://spec.graphql.org/October2021/#sec-Lone-Anonymous-Operation)
-#[derive(Default)]
 pub struct LoneAnonymousOperation {
     operations: usize,
     has_anonymous: bool,
+}
+
+impl<'a> DefaultIn<'a> for LoneAnonymousOperation {
+    fn default_in(_arena: &'a bumpalo::Bump) -> Self {
+        Self {
+            operations: 0,
+            has_anonymous: false
+        }
+    }
 }
 
 impl<'a> ValidationRule<'a> for LoneAnonymousOperation {}

--- a/src/validate/rules/no_unused_fragments.rs
+++ b/src/validate/rules/no_unused_fragments.rs
@@ -1,3 +1,5 @@
+use bumpalo::collections::Vec;
+
 use super::super::{ValidationContext, ValidationRule};
 use crate::{ast::*, visit::*};
 
@@ -5,10 +7,18 @@ use crate::{ast::*, visit::*};
 ///
 /// See [`ValidationRule`]
 /// [Reference](https://spec.graphql.org/October2021/#sec-Fragments-Must-Be-Used)
-#[derive(Default)]
 pub struct NoUnusedFragments<'a> {
-    fragment_names: Vec<&'a str>,
-    fragment_spreads: Vec<&'a str>,
+    fragment_names: Vec<'a, &'a str>,
+    fragment_spreads: Vec<'a, &'a str>,
+}
+
+impl<'a> DefaultIn<'a> for NoUnusedFragments<'a> {
+    fn default_in(arena: &'a bumpalo::Bump) -> Self {
+        Self {
+            fragment_names: Vec::new_in(arena),
+            fragment_spreads: Vec::new_in(arena),
+        }
+    }
 }
 
 impl<'a> ValidationRule<'a> for NoUnusedFragments<'a> {}

--- a/src/validate/rules/unique_argument_names.rs
+++ b/src/validate/rules/unique_argument_names.rs
@@ -1,3 +1,5 @@
+use bumpalo::collections::Vec;
+
 use super::super::{ValidationContext, ValidationRule};
 use crate::{ast::*, visit::*};
 
@@ -5,9 +7,16 @@ use crate::{ast::*, visit::*};
 ///
 /// See [`ValidationRule`]
 /// [Reference](https://spec.graphql.org/October2021/#sec-Argument-Uniqueness)
-#[derive(Default)]
 pub struct UniqueArgumentNames<'a> {
-    used_argument_names: Vec<&'a str>,
+    used_argument_names: Vec<'a, &'a str>,
+}
+
+impl<'a> DefaultIn<'a> for UniqueArgumentNames<'a> {
+    fn default_in(arena: &'a bumpalo::Bump) -> Self {
+        Self {
+            used_argument_names: Vec::new_in(arena),
+        }
+    }
 }
 
 impl<'a> ValidationRule<'a> for UniqueArgumentNames<'a> {}

--- a/src/validate/rules/unique_fragment_names.rs
+++ b/src/validate/rules/unique_fragment_names.rs
@@ -1,3 +1,5 @@
+use bumpalo::collections::Vec;
+
 use super::super::{ValidationContext, ValidationRule};
 use crate::{ast::*, visit::*};
 
@@ -6,9 +8,16 @@ use crate::{ast::*, visit::*};
 ///
 /// See [`ValidationRule`]
 /// [Reference](https://spec.graphql.org/October2021/#sec-Fragment-Name-Uniqueness)
-#[derive(Default)]
 pub struct UniqueFragmentNames<'a> {
-    used_fragment_names: Vec<&'a str>,
+    used_fragment_names: Vec<'a, &'a str>,
+}
+
+impl<'a> DefaultIn<'a> for UniqueFragmentNames<'a> {
+    fn default_in(arena: &'a bumpalo::Bump) -> Self {
+        Self {
+            used_fragment_names: Vec::new_in(arena),
+        }
+    }
 }
 
 impl<'a> ValidationRule<'a> for UniqueFragmentNames<'a> {}

--- a/src/validate/rules/unique_operation_names.rs
+++ b/src/validate/rules/unique_operation_names.rs
@@ -1,3 +1,5 @@
+use bumpalo::collections::Vec;
+
 use super::super::{ValidationContext, ValidationRule};
 use crate::{ast::*, visit::*};
 
@@ -6,9 +8,16 @@ use crate::{ast::*, visit::*};
 ///
 /// See [`ValidationRule`]
 /// [Reference](https://spec.graphql.org/October2021/#sec-Operation-Name-Uniqueness)
-#[derive(Default)]
 pub struct UniqueOperationNames<'a> {
-    used_operation_names: Vec<&'a str>,
+    used_operation_names: Vec<'a, &'a str>,
+}
+
+impl<'a> DefaultIn<'a> for UniqueOperationNames<'a> {
+    fn default_in(arena: &'a bumpalo::Bump) -> Self {
+        Self {
+            used_operation_names: Vec::new_in(arena),
+        }
+    }
 }
 
 impl<'a> ValidationRule<'a> for UniqueOperationNames<'a> {}

--- a/src/validate/rules/unique_variable_names.rs
+++ b/src/validate/rules/unique_variable_names.rs
@@ -1,3 +1,5 @@
+use bumpalo::collections::Vec;
+
 use super::super::{ValidationContext, ValidationRule};
 use crate::{ast::*, visit::*};
 
@@ -6,9 +8,16 @@ use crate::{ast::*, visit::*};
 ///
 /// See [`ValidationRule`]
 /// [Reference](https://spec.graphql.org/October2021/#sec-Variable-Uniqueness)
-#[derive(Default)]
 pub struct UniqueVariableNames<'a> {
-    used_variable_names: Vec<&'a str>,
+    used_variable_names: Vec<'a, &'a str>,
+}
+
+impl<'a> DefaultIn<'a> for UniqueVariableNames<'a> {
+    fn default_in(arena: &'a bumpalo::Bump) -> Self {
+        Self {
+            used_variable_names: Vec::new_in(arena),
+        }
+    }
 }
 
 impl<'a> ValidationRule<'a> for UniqueVariableNames<'a> {}


### PR DESCRIPTION
This replaces the need for the `Default` trait with `DefaultIn` so that we always allocate everything on our arena. This speeds up validation considerably.